### PR TITLE
Added asterisk to HTTP Provider XML snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The ad demo HTTP Provider allows Wowza Streaming Engine to accept an HTTP POST r
 ```
 <HTTPProvider>
 	<BaseClass>com.wowza.wms.plugin.addemo.HTTPProviderAdBreakInsertion</BaseClass>
-	<RequestFilters>insertadmarker</RequestFilters>
+	<RequestFilters>insertadmarker*</RequestFilters>
 	<AuthenticationMethod>none</AuthenticationMethod>
 </HTTPProvider>
 ```


### PR DESCRIPTION
This wasn't working for me and then I realized that all of the other examples I could find in the VHost.xml file, and online, included an asterisk with the `RequestFilters` key in the XML.
